### PR TITLE
Support configuring the shutdown chain in reverse order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ node_modules
 
 # Optional npm cache directory
 .npm
+package-lock.json
 
 # Optional REPL history
 .node_repl_history

--- a/README.md
+++ b/README.md
@@ -18,13 +18,19 @@ let shutdownHook = new ShutdownHook(options)
 | Property | Description | Default Value |
 | :------: | :---------- | :-----------: |
 | timeout  | Sets a timeout in ms for the shutdown operation to complete. If the shutdown operations exceed the timeout, the process will exit with code 1| 10000ms |
+| lifo     | Reverses the execution order of the shutdown functions| false |
 
 
 ### Add shutdown functions:
 
 `shutdownHook.add(_ => doSomething(), options)`
 
-Shutdown functions are executed in the order they were added unless `options.order` was specified. Shutdown function should return nothing, a value, a Promise, or throw an error.
+Shutdown functions are executed in the order they were added unless: 
+
+1. `options.order` was specified. 
+2. `lifo: true` was specified when instantiating the hook.
+
+Shutdown function can return nothing, a value, a Promise, or throw an error.
 A rejected promise or error will stop the shutdown sequence (subsequent functions will not be run) and exit the process with code 1.
 
 You can also name shutdown functions:

--- a/lib/shutdown.hook.js
+++ b/lib/shutdown.hook.js
@@ -6,6 +6,7 @@ var Promise      = require('bluebird'),
 function ShutdownHook(options) {
   options = options || {};
   this.shutdownFunctions = [];
+  this.lifo = options.lifo || false;
   this.timeout = options.timeout || 10000;
 }
 
@@ -34,7 +35,9 @@ ShutdownHook.prototype.shutdown = function() {
   return Promise.try(function() {
     self.emit('ShutdownStarted');
 
+    self.shutdownFunctions = self.lifo ? _.reverse(self.shutdownFunctions) : self.shutdownFunctions;
     var sortedFunctions = _.sortBy(self.shutdownFunctions, "order");
+
     return Promise.each(sortedFunctions, function(shutdownFunctionDescriptor, index) {
       self.emit('ComponentShutdown', {name: shutdownFunctionDescriptor.name, order: shutdownFunctionDescriptor.order, index: index})
       var shutdownFn = shutdownFunctionDescriptor.fn;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shutdown-hook",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Injectable shutdown hook for Node.js applications",
   "main": "index.js",
   "scripts": {

--- a/test/shutdown.hook.spec.js
+++ b/test/shutdown.hook.spec.js
@@ -90,6 +90,73 @@ describe('Shutdown hook', function() {
       })
     })
 
+    describe('setting lifo to true', function() {
+
+      it('should call the shutdown functions in reverse order', function() {
+        var exitSpy = sinon.spy();
+        var hook = new ShutdownHook({ lifo: true });
+        hook.exit = exitSpy
+        var f1 = sinon.spy();
+        var f2 = sinon.spy();
+        hook.add(f1);
+        hook.add(f2);
+        return hook.shutdown().then(function() {
+          expect(f2).to.be.calledBefore(f1);
+        })
+      })
+    })
+
+    describe('setting lifo to false', () => {
+
+      it('should call the shutdown functions in order of insertion', () => {
+        var exitSpy = sinon.spy();
+        var hook = new ShutdownHook({ lifo: false });
+        hook.exit = exitSpy
+        var f1 = sinon.spy();
+        var f2 = sinon.spy();
+        hook.add(f1);
+        hook.add(f2);
+        return hook.shutdown().then(function() {
+          expect(f1).to.be.calledBefore(f2);
+        });
+      })
+    })
+
+    describe('not setting lifo', () => {
+
+      it('should call the shutdown functions in order of insertion', () => {
+        var exitSpy = sinon.spy();
+        var hook = new ShutdownHook();
+        hook.exit = exitSpy
+        var f1 = sinon.spy();
+        var f2 = sinon.spy();
+        hook.add(f1);
+        hook.add(f2);
+        return hook.shutdown().then(function() {
+          expect(f1).to.be.calledBefore(f2);
+        });
+      })
+    })
+
+    describe('setting both order and lifo', () => {
+      it('should take into account only order', () => {
+        var exitSpy = sinon.spy();
+        var hook = new ShutdownHook({ lifo: true });
+        hook.exit = exitSpy
+        var f1 = sinon.spy();
+        var f2 = sinon.spy();
+        var f3 = sinon.spy();
+        var f4 = sinon.spy();
+        hook.add(f1, {name: "f1"});
+        hook.add(f2, { order: 2, name: "f2"});
+        hook.add(f3, { order: 1, name: "f3" });
+        return hook.shutdown().then(function() {
+          expect(f1).to.be.calledBefore(f3);
+          expect(f3).to.be.calledBefore(f2);
+        });
+      })
+    })
+
     it('should exit with exit code 1 in case the shutdown operation exceeds the provided timeout', function() {
       var exitSpy = sinon.spy();
       var timeout = 200;


### PR DESCRIPTION
This should actually be the default behavior but due to backwards
compatibility we have to keep the default as is and just allow to
reverse the order using a configuration parameter.