### PR TITLE
Call shutdown only once

### DIFF
--- a/lib/shutdown.hook.js
+++ b/lib/shutdown.hook.js
@@ -8,6 +8,7 @@ function ShutdownHook(options) {
   this.shutdownFunctions = [];
   this.lifo = options.lifo || false;
   this.timeout = options.timeout || 10000;
+  this.shuttingDown = false;
 }
 
 util.inherits(ShutdownHook, EventEmitter);
@@ -31,6 +32,10 @@ ShutdownHook.prototype.exit = function(code) {
 }
 
 ShutdownHook.prototype.shutdown = function() {
+  if (this.shuttingDown) {
+    return;
+  }
+  this.shuttingDown = true;
   var self = this;
   return Promise.try(function() {
     self.emit('ShutdownStarted');


### PR DESCRIPTION
If for some reason a signal was called more than once, still only shutdown once